### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+# This workflow runs the pipeline with the minimal test dataset to check that
+# it completes without errors
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+    draft: true
+
+env:
+  NXF_ANSI_LOG: false
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Install and run self-test pipeline
+    # Only run on push if this is in the main repository
+    if: "${{ github.repository == 'genomic-medicine-sweden/gms_16s' }}"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        NXF_VER:
+          - "24.10.0"
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@v3
+
+      - name: Install Nextflow
+        # For running (locally) with ACT, we use a docker image with Nextflow pre-installed
+        if: "${{ ! github.event.act }}"
+        uses: nf-core/setup-nextflow@v1
+        with:
+          version: "${{ matrix.NXF_VER }}"
+
+      - name: Install nf-test
+        uses: nf-core/setup-nf-test@v1
+
+      - name: Install Singularity
+        # For running (locally) with ACT, we use a docker image with Singularity already installed
+        if: "${{ ! github.event.act }}"
+        run: |
+          wget https://github.com/apptainer/singularity/releases/download/v3.8.7/singularity-container_3.8.7_amd64.deb && sudo dpkg -i singularity-container_3.8.7_amd64.deb
+
+      - name: Report disk-usage before make install
+        run:
+          df -h
+
+      - name: Run Make install
+        run:
+          make install
+
+      - name: Report disk-usage after make install
+        run:
+          df -h
+
+      # The below snippet is kept for now, if for debugging purposes you would
+      # want to run a test pipeline without nf-test
+      #- name: Run pipeline with test data
+      #  run: |
+      #    nextflow  \
+      #      -log $(pwd)/nextflow.log \
+      #      run main.nf \
+      #      --outdir results \
+      #      --db $(pwd)/assets/databases/emu_database \
+      #      --seqtype map-ont \
+      #       -profile singularity,test \
+      #      --quality_filtering \
+      #      --longread_qc_qualityfilter_minlength 1200 \
+      #      --longread_qc_qualityfilter_maxlength 1800 \
+      #      --merge_fastq_pass $(pwd)/assets/test_assets/ci; \
+
+      - name: Run nf-test
+        run: |
+          nf-test test tests/main.nf.test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,161 @@
+# ==============================================================================
+# Brief explanation of Makefile syntax
+# ==============================================================================
+# Since Makefiles are a bit special, and there are not a lot of easy to read
+# tutorials out there, here follows a very brief introduction to the syntax in
+# Makefiles.
+#
+# Basics
+# ------------------------------------------------------------------------------
+#
+# Makefiles are in many ways similar to bash-scripts, but unlike bash-scripts
+# they are not written in a linear sequential fashion, but rather divided into
+# so called rules, that are typically tightly connected to specific output file
+# paths or file path pattern.
+#
+# Firstly, Makefiles should be named `Makefile` and be put inside a folder
+# where one wants to run the make command.
+#
+# The rule syntax
+# ------------------------------------------------------------------------------
+#
+# The syntax of a rule is at its core very simple:
+#
+# output file(s)/target(s) : any dependent input files
+#     commands to produce the output files from input files
+#     possibly more commands
+#
+# So, the significant part of the rule syntax is the ':'-character, as well as
+# the indentation of the rows following the head of the rule, to indicate the
+# "recipe" or the commands to produce the outputs of the rule.
+#
+# A rule can also have just a name, and no concrete output file. That is, it
+# would have the form:
+#
+# name_of_the_rule : any dependent input files
+#     one commands
+#     more commands
+#
+# Now, there is one big caveat here, related to our scripts: Make will rebuild
+# a target as soon as any of its inputs are updated, or have a newer timestamp
+# than the target. This is typically not desired for us, since we might have
+# files unpacked with zip with all kinds of different dates, and for a one-run
+# installation, we are mostly interested in wheter an output file already
+# exists or not, not so much about timestamps.
+#
+# To change so that Make only cares about whether files exist, and not timestamps,
+# one can add a | character before those input files, like so:
+#
+# name_of_the_rule : input files where timestamp matters | input files where only existence matters
+#     one commands
+#     more commands
+#
+# Of course, one can have everything on the right side of the | character, so:
+#
+# name_of_the_rule : | input files where only existence matters
+#     one commands
+#     more commands
+#
+# Running Makefiles
+# ------------------------------------------------------------------------------
+#
+# To run a named rule, you would then do:
+#
+# $ make name_of_the_rule
+#
+# For normal rules, you would hit:
+#
+# $ make <outputfile>
+#
+# Tip: Type "make" and hit tab twice in the shell, to show available targets to
+# run in the current makefile.
+#
+# Special variables and more
+# ------------------------------------------------------------------------------
+#
+# Inside the commands of the rules, one can write pretty much bash, especially
+# if setting `SHELL := /bin/bash` in the beginning of the Makefile which we have
+# done below.
+#
+# There are a some differences though:
+#
+# 1. Variable syntax using only a single $-character refer to MAKE-variables.
+#    Thus, to use variables set in bash, you have to use double-$.
+#    So:
+#    echo $(this-is-a-make-variable) and $$(this-is-a-bash-variable)
+#
+#    This also goes for command substitution, so rather than:
+#
+#    	echo "Lines in file:" $(wc -l somefile.txt)
+#
+#    ... you would write:
+#
+#    	echo "Lines in file:" $$(wc -l somefile.txt)
+#
+# 2. Makefiles also use some special variables with special meaning, to access
+#    things like the output and input files:
+#
+#    $@   The output target (In case of multiple targets, the same command will
+#         be run once for every output file, feeding this variable with only a
+#         single one at a time)
+#
+#    $<   The first input file or dependency
+#
+#    $^   ALL input files / dependencies.
+#
+# 3. Another speciality is that adding a '@' character before any command, will
+#    stop this command from being printed out when it is executed (only its output
+#    will be printed).
+#
+# That's all for now. For the official docs, see:
+# https://www.gnu.org/software/make/manual/make.html
+#
+# Some more caveats
+# ------------------------------------------------------------------------------
+#  Here are some things that might not be obvious at first:
+#
+#  To create a rule with a single output but many dependencies, you can add
+#  these dependencies on multiple lines by using the continuation character \
+#  like so:
+#
+#  name_of_rule: dependency1 \
+#  		dependency2 \
+#  		dependency3 \
+#  		dependency4 \
+
+# ==============================================================================
+# Various definitions
+# ==============================================================================
+# Make sure bash is used as shell, for consistency and to make some more
+# advanced scripting possible than with /bin/sh
+SHELL := /bin/bash
+
+# Define path variables
+SCRIPT_DIR := $(shell pwd)
+ASSETS_DIR := $(shell realpath $(SCRIPT_DIR)/assets/)
+CONTAINER_DIR := $(realpath $(SCRIPT_DIR)/container/)
+# The root folder where the pipeline is currently located. To be mounted into
+# the Singularity containers below.
+MNT_ROOT := /$(shell readlink -f . | cut -d"/" -f2)
+INSTALL_LOG := "$(SCRIPT_DIR)/.install.log"
+
+define log_message
+	@echo "--------------------------------------------------------------------------------" | tee -a $(INSTALL_LOG);
+	@echo "$$(date "+%Y-%m-%d %H:%M:%S"): $1" | tee -a $(INSTALL_LOG);
+	@echo "--------------------------------------------------------------------------------" | tee -a $(INSTALL_LOG);
+endef
+
+# ==============================================================================
+# Main rules
+# ==============================================================================
+
+install: assets/databases/emu_database/species_taxid.fasta assets/databases/emu_database/taxonomy.tsv assets/databases/krona/taxonomy/taxonomy.tab
+
+assets/databases/emu_database/species_taxid.fasta: assets/databases/emu_database/species_taxid.fasta.gz
+	zcat $< > $@
+
+assets/databases/emu_database/taxonomy.tsv: assets/databases/emu_database/taxonomy.tsv.gz
+	zcat $< > $@
+
+assets/databases/krona/taxonomy/taxonomy.tab: assets/databases/krona/taxonomy/taxonomy.tab.gz
+	zcat $< > $@

--- a/assets/test_assets/ci/barcode01/medium_Mock_dil_1_2_BC1.fastq.gz
+++ b/assets/test_assets/ci/barcode01/medium_Mock_dil_1_2_BC1.fastq.gz
@@ -1,0 +1,1 @@
+../../medium_Mock_dil_1_2_BC1.fastq.gz

--- a/assets/test_assets/ci/barcode01/medium_Mock_dil_1_2_BC3.fastq.gz
+++ b/assets/test_assets/ci/barcode01/medium_Mock_dil_1_2_BC3.fastq.gz
@@ -1,0 +1,1 @@
+../../medium_Mock_dil_1_2_BC3.fastq.gz

--- a/assets/test_assets/ci/barcode02/medium_Mock_dil_1_2_BC1.fastq.gz
+++ b/assets/test_assets/ci/barcode02/medium_Mock_dil_1_2_BC1.fastq.gz
@@ -1,0 +1,1 @@
+../../medium_Mock_dil_1_2_BC1.fastq.gz

--- a/assets/test_assets/ci/barcode02/medium_Mock_dil_1_2_BC3.fastq.gz
+++ b/assets/test_assets/ci/barcode02/medium_Mock_dil_1_2_BC3.fastq.gz
@@ -1,0 +1,1 @@
+../../medium_Mock_dil_1_2_BC3.fastq.gz

--- a/conf/test.config
+++ b/conf/test.config
@@ -23,3 +23,33 @@ params {
     // TODO nf-core: Specify the paths to your test data on nf-core/test-datasets
     // TODO nf-core: Give any required params for the test so that command line flags are not needed
 }
+
+process {
+    cpus = 2
+    memory = 12.GB
+    time = 1.h
+
+    withLabel:process_medium {
+        cpus = 2
+        memory = 12.GB
+        time = 1.h
+    }
+
+    withLabel:process_high {
+        cpus = 2
+        memory = 12.GB
+        time = 1.h
+    }
+
+    withLabel:process_long {
+        cpus = 2
+        memory = 12.GB
+        time = 1.h
+    }
+
+    withLabel:process_high_memory {
+        cpus = 2
+        memory = 12.GB
+        time = 1.h
+    }
+}

--- a/conf/test.config
+++ b/conf/test.config
@@ -29,6 +29,9 @@ process {
     memory = 12.GB
     time = 1.h
 
+    // The below sections are needed in order to override the corresponding
+    // settings in base.config
+
     withLabel:process_medium {
         cpus = 2
         memory = 12.GB

--- a/nf-test.config
+++ b/nf-test.config
@@ -1,0 +1,6 @@
+config {
+    testsDir "tests"
+    workDir ".nf-test"
+    configFile "conf/test.config"
+    profile "singularity,test"
+}

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -1,0 +1,27 @@
+nextflow_pipeline {
+
+    name "Test Main Pipeline"
+    script "main.nf"
+
+    test("Should run pipeline with test profile") {
+
+        when {
+            params {
+                outdir = "$projectDir/results"
+                db = "$projectDir/assets/databases/emu_database"
+                seqtype = "map-ont"
+                quality_filtering = true
+                longread_qc_qualityfilter_minlength = 1200
+                longread_qc_qualityfilter_maxlength = 1800
+                merge_fastq_pass = "$projectDir/assets/test_assets/ci"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert workflow.trace.succeeded().size() > 0 // Adjust this number based on the number of processes in your pipeline
+            assert path("$projectDir/results/results/barcode01_T1_filtered.fastq_rel-abundance.tsv").exists()
+            assert path("$projectDir/results/results/barcode02_T1_filtered.fastq_rel-abundance.tsv").exists()
+        }
+    }
+}


### PR DESCRIPTION
Having a basic Continuous Integration (CI) pipeline, that runs at least on pull requests, would go a long way towards ensuring we are not accidentally breaking important functionality when developing new features.

This PR adds a very basic CI pipeline based on GitHub actions. It simply runs the pipeline on a really small set of data; two copies of the medium size dataset already available in the assets folder.