### PR TITLE
Conditionally emit nanostats_unprocessed 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed unused `NANOPLOT2` to `NANOPLOT_PROCESSED_READS`
 - Fixed `Nanoplot` output dirs and prefix in `modules.config`
 - Fixed Dockerfile context
+- Conditionally emit nanostats_unprocessed to avoid undefined output error when using --seqtype SR
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed unused `NANOPLOT2` to `NANOPLOT_PROCESSED_READS`
 - Fixed `Nanoplot` output dirs and prefix in `modules.config`
 - Fixed Dockerfile context
-- Conditionally emit nanostats_unprocessed to avoid undefined output error when using --seqtype SR
+- Moved nanostats_unprocessed process execution into seqtype SR if statement
 
 ### Changed
 

--- a/workflows/gmsemu.nf
+++ b/workflows/gmsemu.nf
@@ -111,6 +111,12 @@ workflow GMSEMU {
             ch_reads.set{ ch_processed_reads }
         }
 
+        //
+        // MODULE: run NANOPLOT_PROCESSED_READS
+        //
+        NANOPLOT_PROCESSED_READS(ch_processed_reads)
+        ch_versions = ch_versions.mix(NANOPLOT_PROCESSED_READS.out.versions.first())
+
     } else if (params.seqtype == "sr") {
 
         //
@@ -126,12 +132,6 @@ workflow GMSEMU {
     } else {
         error "Invalid seqtype. Please specify either 'map-ont' or 'sr'."
     }
-
-    //
-    // MODULE: run NANOPLOT_PROCESSED_READS
-    //
-    NANOPLOT_PROCESSED_READS(ch_processed_reads)
-    ch_versions = ch_versions.mix(NANOPLOT_PROCESSED_READS.out.versions.first())
 
     //
     // MODULE: run EMU abundance calculation
@@ -190,7 +190,7 @@ workflow GMSEMU {
     ch_versions = ch_versions.mix(GENERATE_MASTER_HTML.out.versions.first())
 
     emit:
-    nanostats_unprocessed   = params.seqtype == "map-ont" ? NANOPLOT_UNPROCESSED_READS.out.txt : Channel.empty() // channel: [ path(versions.yml) ]
+    nanostats_unprocessed   = NANOPLOT_UNPROCESSED_READS.out.txt // channel: [ path(versions.yml) ]
     nanostats_processed     = NANOPLOT_PROCESSED_READS.out.txt   // channel: [ path(versions.yml) ]
     versions                = ch_versions                        // channel: [ path(versions.yml) ]
 

--- a/workflows/gmsemu.nf
+++ b/workflows/gmsemu.nf
@@ -190,7 +190,7 @@ workflow GMSEMU {
     ch_versions = ch_versions.mix(GENERATE_MASTER_HTML.out.versions.first())
 
     emit:
-    nanostats_unprocessed   = NANOPLOT_UNPROCESSED_READS.out.txt // channel: [ path(versions.yml) ]
+    nanostats_unprocessed   = params.seqtype == "map-ont" ? NANOPLOT_UNPROCESSED_READS.out.txt : Channel.empty() // channel: [ path(versions.yml) ]
     nanostats_processed     = NANOPLOT_PROCESSED_READS.out.txt   // channel: [ path(versions.yml) ]
     versions                = ch_versions                        // channel: [ path(versions.yml) ]
 


### PR DESCRIPTION
Conditionally emit nanostats_unprocessed to avoid undefined output error when --seqtype SR 