### PR TITLE
Fix failing CI in dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,6 @@ jobs:
         exclude:
           - is_master: false
             profile: "conda"
-          - is_master: false
-            profile: "singularity"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
     strategy:
       matrix:
         NXF_VER:
-          - "24.10.0"
           - "latest-everything"
         profile:
           - "conda"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved nanostats_unprocessed process execution into seqtype SR if statement
 - Conditionally emit nanostats unprocessed/processed to avoid undefined output error when using --seqtype SR
 - Fixed a broken configuration file in `modules/local/emu/abundance/meta.yml`
+- Fixed failing pulls of some singularity containers by settings singularity.cacheDir
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -172,4 +172,18 @@ lint:
 test:
 	nf-test test
 
+test-cli:
+	nextflow  \
+		-log $$(pwd)/nextflow.log \
+		run main.nf \
+		-profile singularity,test \
+		--outdir results \
+		--db $$(pwd)/assets/databases/emu_database \
+		--seqtype map-ont \
+		--quality_filtering \
+		--longread_qc_qualityfilter_minlength 1200 \
+		--longread_qc_qualityfilter_maxlength 1800 \
+		--merge_fastq_pass $$(pwd)/assets/test_assets/ci
+
+
 check: precommit lint test

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ nextflow run main.nf \
 
 ## Runs with shortreads
 
-When running TACO with short reads, the primer sequences are trimmed using cutadapt by default using the provided primer sequences.
-The primer sequences can be provided in the samplesheet or passed as arguments (FW_primer, RV_primer). Primer trimming with cutadapt can be skipped with --skip_cutadapt.
+When running TACO with short reads, the primer sequences are trimmed using Cutadapt by default using the provided primer sequences.
+The primer sequences can be provided in the sample-sheet or passed as arguments (FW_primer, RV_primer). Primer trimming with Cutadapt can be skipped with --skip_cutadapt.
 
 ```bash
 sample,fastq_1,fastq_2,FW_primer,RV_primer
@@ -145,7 +145,7 @@ nextflow run main.nf \
 There are two types of sample sheets that can be used:
 
 1. If the fastq files are already concatenated/merged i.e., the fastq-files in
-   Nanopore barcode directories have been concataned already, the `--input` can
+   Nanopore barcode directories have been concatenated already, the `--input` can
    be used. `--input` expects a `.csv` sample sheet with 3 columns (note the
    header names). It looks like this (See also the `examples` directory):
    ```csv
@@ -155,7 +155,7 @@ There are two types of sample sheets that can be used:
    ```
 2. If the fastq files are separated in their respective barcode folder i.e., you
    have several fastq files for each sample and they are organized in barcode
-   directories in a fastq_pass dir.
+   directories in a fastq_pass directory.
    a) If you do not want to create a sample sheet for the barcodes, then the
    results will be named according to the barcode folders. flag
    `--merge_fastq_pass`

--- a/nextflow.config
+++ b/nextflow.config
@@ -160,6 +160,7 @@ profiles {
     singularity {
         singularity.enabled    = true
         singularity.autoMounts = true
+        singularity.cacheDir   = '/tmp'
         docker.enabled         = false
         podman.enabled         = false
         shifter.enabled        = false


### PR DESCRIPTION
This is an attempt to fix errors when running the current version of the pipeline in dev (commit ecbbce15fb8cb33e457695e0c51c16e386c4eb75), that caused this error in `nextflow.log`:

```log
Apr-23 15:31:36.811 [Actor Thread 3] DEBUG nextflow.processor.TaskProcessor - Handling unexpected condition for
  task: name=GMS_TACO:taco:NANOPLOT_UNPROCESSED_READS (2); work-dir=null
  error [java.lang.IllegalStateException]: java.lang.IllegalStateException: Failed to pull singularity image
  command: singularity pull  --name community-cr-prod.seqera.io-docker-registry-v2-blobs-sha256-96-9633ba7d2adf5e17e7d219d60efebb1d1e76cbea6e3f7440320f11cc99da37ac-data.img.pulling.1745415096751 https://community-cr-prod.seqera.io/docker/registry/v2/blo>
  status : 255
  hint   : Try and increase singularity.pullTimeout in the config (current is "30m")
  message:
    FATAL:   Image file already exists: "community-cr-prod.seqera.io-docker-registry-v2-blobs-sha256-96-9633ba7d2adf5e17e7d219d60efebb1d1e76cbea6e3f7440320f11cc99da37ac-data.img.pulling.1745415096751" - will not overwrite
```