### PR TITLE
80 nanoplot not working properly in branch dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,14 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed unused `NANOPLOT2` to `NANOPLOT_PROCESSED_READS`
-- Fixed `Nanoplot` output dirs and prefix in `modules.config`
+- Readded `NANOPLOT2` as `NANOPLOT_PROCESSED_READS`
 - Fixed Dockerfile context
 - Moved nanostats_unprocessed process execution into seqtype SR if statement
 - Conditionally emit nanostats unprocessed/processed to avoid undefined output error when using --seqtype SR
 - Fixed a broken configuration file in `modules/local/emu/abundance/meta.yml`
 - Fixed failing pulls of some singularity containers by settings singularity.cacheDir
-
+- Fixed broken nanoplot code. Readded prefixes to the module.
+ 
 ### Changed
 
 - `merge_barcodes_samplesheet.py` can now handle custom barcodes.
@@ -61,6 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   assets and useful `make` commands for developers.
 - Updated workflow image
 - Made phyloseq an option to protect against errors when using other databases than emu´s premade.
+- Added peoples github names to README for credit
+- Added nanoplot unprocessed reads and processed reads to multiqc. Short info about this in README.
 
 ## [v0.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a broken configuration file in `modules/local/emu/abundance/meta.yml`
 - Fixed failing pulls of some singularity containers by settings singularity.cacheDir
 - Fixed broken nanoplot code. Readded prefixes to the module.
- 
+
 ### Changed
 
 - `merge_barcodes_samplesheet.py` can now handle custom barcodes.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ APPTAINER_TMPDIR
 NXF_SINGULARITY_CACHEDIR
 APPTAINER_CACHEDIR
 ```
+## Multiqc report
+Fastqc results will be shown only for unprocessed reads. For runs using the 'map-ont' flag, qc-results from nanoplot will be
+shown for unprocessed and processed reads.
+
 
 ## Useful commands for developers
 
@@ -193,7 +197,16 @@ then hit `TAB` twice.
 
 ## Credits
 
-TACO was originally written by [@fwa93](https://github.com/fwa93).
+TACO was originally written by [@fwa93](https://github.com/fwa93) and is further developed and
+maintained by gms-mikro from Genomic Medicine Sweden:
+@samuell
+@ryanjameskennedy
+@sofstam
+@AnderssonOlivia
+@kdannenberg
+@ikarls
+@bokelund
+
 
 This pipeline is not a formal nf-core pipeline but it partly uses code and
 infrastructure developed and maintained by the [nf-core](https://nf-co.re)

--- a/README.md
+++ b/README.md
@@ -174,10 +174,11 @@ APPTAINER_TMPDIR
 NXF_SINGULARITY_CACHEDIR
 APPTAINER_CACHEDIR
 ```
+
 ## Multiqc report
+
 Fastqc results will be shown only for unprocessed reads. For runs using the 'map-ont' flag, qc-results from nanoplot will be
 shown for unprocessed and processed reads.
-
 
 ## Useful commands for developers
 
@@ -206,7 +207,6 @@ maintained by gms-mikro from Genomic Medicine Sweden:
 @kdannenberg
 @ikarls
 @bokelund
-
 
 This pipeline is not a formal nf-core pipeline but it partly uses code and
 infrastructure developed and maintained by the [nf-core](https://nf-co.re)

--- a/modules/nf-core/nanoplot/main.nf
+++ b/modules/nf-core/nanoplot/main.nf
@@ -24,12 +24,14 @@ process NANOPLOT {
     def args = task.ext.args ?: ''
     def input_file = ("$ontfile".endsWith(".fastq.gz") || "$ontfile".endsWith(".fq.gz")) ? "--fastq ${ontfile}" :
         ("$ontfile".endsWith(".txt")) ? "--summary ${ontfile}" : ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
     """
     NanoPlot \\
         $args \\
         -t $task.cpus \\
-        $input_file
-
+        $input_file \\
+        -p $prefix
+    
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         nanoplot: \$(echo \$(NanoPlot --version 2>&1) | sed 's/^.*NanoPlot //; s/ .*\$//')

--- a/workflows/taco.nf
+++ b/workflows/taco.nf
@@ -210,6 +210,11 @@ workflow TACO {
     ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml'))
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
     ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
+    // collect nanoplot
+    if (params.seqtype = "map-ont") {
+        ch_multiqc_files = ch_multiqc_files.mix(NANOPLOT_UNPROCESSED_READS.out.txt.collect {it[1] })
+        ch_multiqc_files = ch_multiqc_files.mix(NANOPLOT_PROCESSED_READS.out.txt.collect {it[1] })
+    }
 
     if (params.seqtype == "sr" && !params.skip_cutadapt) {
         ch_multiqc_files = ch_multiqc_files.mix(CUTADAPT.out.log.collect { it[1] })


### PR DESCRIPTION
Fixes the issue about nanoplot.
Nanoplot now creates prefixed reports and these are also added to multiqc if the 'map-ont' was used. 
Added some info about multiqc to README.
Also added some credits to README