### PR TITLE
Fix #88: Add tests for short-read data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,4 +102,4 @@ jobs:
       # Run via nf-test for more detailed checking
       - name: Run nf-test
         run: |
-          nf-test test tests/main.nf.test
+          nf-test test tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed authors-field in nextflow.config.
 - Added a module to output the result as a phyloseq object
 - Added figure for pipeline
+- Added an nf-test for short-read, paired-end data
 
 ### Fixed
 
@@ -50,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed broken nanoplot code. Readded prefixes to the module.
 - Fixed broken `--help` screen by adding missing nf-schema plugin and validation config.
 - Fixed broken e-mail sending, where a (corrupt) e-mail would be sent at the start of a pipeline rather than at the end.
+- Fixed a pipeline ordering error in the main workflow where Nanoplot outputs were accessed before executing the module.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,9 @@ precommit:
 lint:
 	nf-core pipelines lint
 
-test:
+check: precommit lint
+
+nf-test:
 	nf-test test
 
 test-cli-fastq:
@@ -190,6 +192,6 @@ test-cli-samplesheet:
 		--db $$(pwd)/assets/databases/emu_database \
 		--input https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/refs/heads/16s/samplesheet.csv
 
-check: precommit lint test test-cli-fastq test-cli-samplesheet
+test: nf-test test-cli-fastq test-cli-samplesheet
 
-test-all: test test-cli-fastq test-cli-samplesheet
+check-and-test: check test

--- a/tests/longread.nf.test
+++ b/tests/longread.nf.test
@@ -1,12 +1,11 @@
 nextflow_pipeline {
-    name "Test Main Pipeline"
+    name "Test main pipeline with long-read data"
     script "main.nf"
 
     test("Should run pipeline with test profile") {
-
+        tag "seqtype-map-ont"
         when {
             params {
-                outdir = "$projectDir/results"
                 db = "$projectDir/assets/databases/emu_database"
                 seqtype = "map-ont"
                 quality_filtering = true
@@ -14,9 +13,9 @@ nextflow_pipeline {
                 longread_qc_qualityfilter_maxlength = 1800
                 merge_fastq_pass = "$projectDir/assets/test_assets/ci"
                 pipelines_testdata_base_path = "https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/refs/heads/16s/"
+                outdir = "$projectDir/results"
             }
         }
-
         then {
             assert workflow.success
             assert workflow.trace.succeeded().size() > 0 // Adjust this number based on the number of processes in your pipeline

--- a/tests/shortread.nf.test
+++ b/tests/shortread.nf.test
@@ -1,0 +1,24 @@
+nextflow_pipeline {
+    name "Test main pipeline with short-read data"
+    script "main.nf"
+
+    test("Should run pipeline with test profile for shortread data") {
+        tag "seqtype-sr"
+        when {
+            params {
+                db = "$projectDir/assets/databases/emu_database"
+                seqtype = "sr"
+                retain_untrimmed = true
+                pipelines_testdata_base_path = "https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/refs/heads/16s/"
+                input = "https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/refs/heads/16s/samplesheet-shortread.csv"
+                outdir = "$projectDir/results"
+            }
+        }
+        then {
+            assert workflow.success
+            assert workflow.trace.succeeded().size() > 0 // Adjust this number based on the number of processes in your pipeline
+            assert path("$projectDir/results/results/SAMPLE_1.trimmed_1.trim.fastq-SAMPLE_1.trimmed_2.trim.fastq_rel-abundance.tsv").exists()
+            assert path("$projectDir/results/results/SAMPLE_2.trimmed_1.trim.fastq-SAMPLE_2.trimmed_2.trim.fastq_rel-abundance.tsv").exists()
+        }
+    }
+}

--- a/workflows/taco.nf
+++ b/workflows/taco.nf
@@ -212,8 +212,8 @@ workflow TACO {
     ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
     // collect nanoplot
     if (params.seqtype = "map-ont") {
-        ch_multiqc_files = ch_multiqc_files.mix(NANOPLOT_UNPROCESSED_READS.out.txt.collect {it[1] })
-        ch_multiqc_files = ch_multiqc_files.mix(NANOPLOT_PROCESSED_READS.out.txt.collect {it[1] })
+        //ch_multiqc_files = ch_multiqc_files.mix(NANOPLOT_UNPROCESSED_READS.out.txt.collect {it[1] })
+        //ch_multiqc_files = ch_multiqc_files.mix(NANOPLOT_PROCESSED_READS.out.txt.collect {it[1] })
     }
 
     if (params.seqtype == "sr" && !params.skip_cutadapt) {

--- a/workflows/taco.nf
+++ b/workflows/taco.nf
@@ -47,6 +47,7 @@ workflow TACO {
     //
     FASTQC (ch_reads)
     ch_versions = ch_versions.mix(FASTQC.out.versions.first())
+    ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{ it[1] })
 
     if (params.seqtype == "map-ont") {
 
@@ -55,7 +56,7 @@ workflow TACO {
         //
         NANOPLOT_UNPROCESSED_READS(ch_reads)
         ch_versions = ch_versions.mix(NANOPLOT_UNPROCESSED_READS.out.versions.first())
-        ch_multiqc_files = ch_multiqc_files.mix(NANOPLOT_UNPROCESSED_READS.out.txt.collect {it[1] })
+        ch_multiqc_files = ch_multiqc_files.mix(NANOPLOT_UNPROCESSED_READS.out.txt.collect{ it[1] })
 
         if (params.adapter_trimming && !params.quality_filtering) {
 
@@ -66,10 +67,10 @@ workflow TACO {
 
             PORECHOP_ABI.out.reads.map {
                 meta, reads -> [meta + [single_end: 1], reads]
-            }.set{ ch_processed_reads }
+            }.set { ch_processed_reads }
 
             ch_versions = ch_versions.mix(PORECHOP_ABI.out.versions.first())
-            ch_multiqc_files = ch_multiqc_files.mix(PORECHOP_ABI.out.log)
+            ch_multiqc_files = ch_multiqc_files.mix(PORECHOP_ABI.out.log.collect{ it[1] })
 
         } else if (!params.adapter_trimming && params.quality_filtering) {
 
@@ -78,10 +79,10 @@ workflow TACO {
             //
             FILTLONG(ch_reads.map {
                 meta, reads -> [meta, [], reads]
-            }).reads.set{ ch_processed_reads}
+            }).reads.set { ch_processed_reads}
 
             ch_versions = ch_versions.mix(FILTLONG.out.versions.first())
-            ch_multiqc_files = ch_multiqc_files.mix(FILTLONG.out.log.collect{it[1]}.ifEmpty([]))
+            ch_multiqc_files = ch_multiqc_files.mix(FILTLONG.out.log.collect{ it[1] })
 
         } else if (params.adapter_trimming && params.quality_filtering) {
 
@@ -92,22 +93,23 @@ workflow TACO {
 
             PORECHOP_ABI.out.reads.map {
                 meta, reads -> [meta + [single_end: 1], reads]
-            }.set{ ch_clipped_reads }
+            }.set { ch_clipped_reads }
+
+            ch_versions = ch_versions.mix(PORECHOP_ABI.out.versions.first())
+            ch_multiqc_files = ch_multiqc_files.mix(PORECHOP_ABI.out.log.collect{ it[1] })
 
             //
             // MODULE: Run filtlong to filter on read length
             //
             FILTLONG(ch_clipped_reads.map {
                 meta, reads -> [meta, [], reads]
-            }).reads.set{ ch_processed_reads }
+            }).reads.set { ch_processed_reads }
 
-            ch_versions = ch_versions.mix(PORECHOP_ABI.out.versions.first())
             ch_versions = ch_versions.mix(FILTLONG.out.versions.first())
-            ch_multiqc_files = ch_multiqc_files.mix(PORECHOP_ABI.out.log)
-            ch_multiqc_files = ch_multiqc_files.mix(FILTLONG.out.log)
+            ch_multiqc_files = ch_multiqc_files.mix(FILTLONG.out.log.collect{ it[1] })
 
         } else {
-            ch_reads.set{ ch_processed_reads }
+            ch_reads.set { ch_processed_reads }
         }
 
         //
@@ -115,7 +117,7 @@ workflow TACO {
         //
         NANOPLOT_PROCESSED_READS(ch_processed_reads)
         ch_versions = ch_versions.mix(NANOPLOT_PROCESSED_READS.out.versions.first())
-        ch_multiqc_files = ch_multiqc_files.mix(NANOPLOT_PROCESSED_READS.out.txt.collect {it[1] })
+        ch_multiqc_files = ch_multiqc_files.mix(NANOPLOT_PROCESSED_READS.out.txt.collect{ it[1] })
 
     } else if (params.seqtype == "sr") {
 
@@ -124,10 +126,11 @@ workflow TACO {
         //
         if (!params.skip_cutadapt) {
             CUTADAPT(ch_reads)
-            CUTADAPT.out.reads.set{ ch_processed_reads }
+            CUTADAPT.out.reads.set { ch_processed_reads }
             ch_versions = ch_versions.mix(CUTADAPT.out.versions.first())
+            ch_multiqc_files = ch_multiqc_files.mix(CUTADAPT.out.log.collect{ it[1] })
         } else {
-            ch_reads.set{ ch_processed_reads }
+            ch_reads.set { ch_processed_reads }
         }
     } else {
         error "Invalid seqtype. Please specify either 'map-ont' or 'sr'."
@@ -137,10 +140,10 @@ workflow TACO {
         //
         // MODULE: Downsample reads
         //
-        SEQTK_SAMPLE( ch_processed_reads, params.sample_size ).reads.set{ ch_processed_sampled_reads }
+        SEQTK_SAMPLE( ch_processed_reads, params.sample_size ).reads.set { ch_processed_sampled_reads }
         ch_versions = ch_versions.mix(SEQTK_SAMPLE.out.versions)
     } else {
-        ch_processed_reads.set{ ch_processed_sampled_reads }
+        ch_processed_reads.set { ch_processed_sampled_reads }
     }
 
     //
@@ -174,7 +177,7 @@ workflow TACO {
         report_ch = EMU_ABUNDANCE.out.report
 
         all_reports_ch = report_ch
-            .map{ meta, path -> path }
+            .map { meta, path -> path }
             .collect()
 
         COMBINE_REPORTS (
@@ -211,12 +214,6 @@ workflow TACO {
     ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
     ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml'))
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
-    ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
-
-    // collect nanoplot
-    if (params.seqtype == "sr" && !params.skip_cutadapt) {
-        ch_multiqc_files = ch_multiqc_files.mix(CUTADAPT.out.log.collect { it[1] })
-    }
 
     MULTIQC (
         ch_multiqc_files.collect(),
@@ -233,11 +230,11 @@ workflow TACO {
     //
 
     ch_reads
-        .map{
+        .map {
             meta, reads -> meta
         }
         .first()
-        .set{ch_meta}
+        .set {ch_meta}
     GENERATE_MASTER_HTML(ch_meta, ch_samplesheet)
     ch_versions = ch_versions.mix(GENERATE_MASTER_HTML.out.versions)
 


### PR DESCRIPTION
This PR adds a test for short-read data, which uses both of the fastq columns in the samplesheet, which is one reason why this is important to test.

It also fixes an apparent pipeline logic/ordering error, where Nanoplot output was accessed before the module had been run, that was exposed by this test.