### PR TITLE
Implement #92: Add tests for the main options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Report disk-usage after make install
         run: df -h
 
+      - name: Run Nextflow lint to catch errors early
+        run: nextflow lint main.nf
+
       # Make sure we can run a full pipeline from the commandline as well
       - name: Run pipeline from the commandline with merge fastq pass
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a module to output the result as a phyloseq object
 - Added figure for pipeline
 - Added an nf-test for short-read, paired-end data
+- Added tests for the combinations of adapter trimming and quality filtering parameters.
+- Added test for downsampling
+- Added running of `nextflow lint` to CI
 
 ### Fixed
 
@@ -52,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed broken `--help` screen by adding missing nf-schema plugin and validation config.
 - Fixed broken e-mail sending, where a (corrupt) e-mail would be sent at the start of a pipeline rather than at the end.
 - Fixed a pipeline ordering error in the main workflow where Nanoplot outputs were accessed before executing the module.
+- Fixed various broken process calls in the main Taco workflow found when adding tests for parameter combinations.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,13 @@ schema:
 precommit:
 	pre-commit run --all-files
 
-lint:
+nf-core-lint:
 	nf-core pipelines lint
+
+nextflow-lint:
+	nextflow lint -o concise main.nf
+
+lint: nextflow-lint nf-core-lint
 
 check: precommit lint
 

--- a/modules/local/merge_barcodes/main.nf
+++ b/modules/local/merge_barcodes/main.nf
@@ -10,7 +10,7 @@ process MERGE_BARCODES {
         'quay.io/biocontainers/python:3.9' }"
 
     input:
-    path('fastq_pass')
+    path fastq_pass
 
     output:
     // publishDir 'fastq_pass_merged', mode: 'move'

--- a/modules/local/merge_barcodes_samplesheet/main.nf
+++ b/modules/local/merge_barcodes_samplesheet/main.nf
@@ -10,8 +10,8 @@ process MERGE_BARCODES_SAMPLESHEET {
         'quay.io/biocontainers/nf-core:3.0.2' }"
 
     input:
-    path('barcodes_samplesheet')
-    path('fastq_pass')
+    path barcodes_samplesheet
+    path fastq_pass
 
     output:
     // publishDir 'fastq_pass_merged'   , mode: 'move'
@@ -21,7 +21,7 @@ process MERGE_BARCODES_SAMPLESHEET {
 
     script:
     """
-    merge_barcodes_samplesheet.py $barcodes_samplesheet fastq_pass_merged $fastq_pass
+    merge_barcodes_samplesheet.py ${barcodes_samplesheet} fastq_pass_merged ${fastq_pass}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/custom/dumpsoftwareversions/main.nf
+++ b/modules/nf-core/custom/dumpsoftwareversions/main.nf
@@ -1,11 +1,3 @@
-def deprecation_message = """
-WARNING: This module has been deprecated.
-
-Reason:
-This module is no longer recommended for use, as it is replaced by the function softwareVersionsToYAML
-in the utils_nfcore_pipeline subworkflow that is included in the nf-core template.
-
-"""
 process CUSTOM_DUMPSOFTWAREVERSIONS {
     label 'process_single'
 
@@ -27,7 +19,13 @@ process CUSTOM_DUMPSOFTWAREVERSIONS {
     task.ext.when == null || task.ext.when
 
     script:
-    assert true: deprecation_message
+    assert true: """
+    WARNING: This module has been deprecated.
+
+    Reason:
+    This module is no longer recommended for use, as it is replaced by the function softwareVersionsToYAML
+    in the utils_nfcore_pipeline subworkflow that is included in the nf-core template.
+    """
     def args = task.ext.args ?: ''
     template 'dumpsoftwareversions.py'
 }

--- a/subworkflows/local/utils_nfcore_taco_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_taco_pipeline/main.nf
@@ -137,18 +137,18 @@ workflow PIPELINE_COMPLETION {
 
     main:
     summary_params = paramsSummaryMap(workflow, parameters_schema: "nextflow_schema.json")
-    def multiqc_reports = multiqc_report.toList()
-
-    //
-    // Completion email and summary
-    //
-
 
     workflow.onComplete {
+        //
+        // Completion email and summary
+        //
         if (email || email_on_fail) {
             completionEmail(summary_params, email, email_on_fail, plaintext_email, outdir, monochrome_logs, multiqc_report)
         }
         completionSummary(monochrome_logs)
+        //
+        // Instant message notification
+        //
         if (hook_url) {
             imNotification(summary_params, hook_url)
         }

--- a/tests/downsample.nf.test
+++ b/tests/downsample.nf.test
@@ -1,25 +1,31 @@
 nextflow_pipeline {
-    name "Test main pipeline with long-read data"
+    name "Test Main Pipeline"
     script "main.nf"
 
-    test("Should run pipeline with test profile") {
+    test("Should run pipeline WITH the --sample-size parameter set") {
         when {
             params {
                 db = "$projectDir/assets/databases/emu_database"
                 seqtype = "map-ont"
-                quality_filtering = true
                 longread_qc_qualityfilter_minlength = 1200
                 longread_qc_qualityfilter_maxlength = 1800
                 merge_fastq_pass = "$projectDir/assets/test_assets/ci"
                 pipelines_testdata_base_path = "https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/refs/heads/16s/"
                 outdir = outputDir
+
+                // The parameters we are varying here
+                sample_size = "100"
             }
         }
         then {
             assert workflow.success
             assert workflow.trace.succeeded().size() > 0 // Adjust this number based on the number of processes in your pipeline
-            assert path("${params.outdir}/results/barcode01_filtered.fastq_rel-abundance.tsv").exists()
-            assert path("${params.outdir}/results/barcode02_filtered.fastq_rel-abundance.tsv").exists()
+            assert path("${params.outdir}/results/barcode01_barcode01_filtered.fastq_rel-abundance.tsv").exists()
+            assert path("${params.outdir}/results/barcode02_barcode02_filtered.fastq_rel-abundance.tsv").exists()
+
+            // Ensure that SeqTK Sample was run
+            assert path("${params.outdir}/seqtk/barcode01_barcode01_filtered.fastq.gz").exists()
+            assert path("${params.outdir}/seqtk/barcode02_barcode02_filtered.fastq.gz").exists()
         }
     }
 }

--- a/tests/longread.nf.test
+++ b/tests/longread.nf.test
@@ -13,14 +13,14 @@ nextflow_pipeline {
                 longread_qc_qualityfilter_maxlength = 1800
                 merge_fastq_pass = "$projectDir/assets/test_assets/ci"
                 pipelines_testdata_base_path = "https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/refs/heads/16s/"
-                outdir = "$projectDir/results"
+                outdir = outputDir
             }
         }
         then {
             assert workflow.success
             assert workflow.trace.succeeded().size() > 0 // Adjust this number based on the number of processes in your pipeline
-            assert path("$projectDir/results/results/barcode01_filtered.fastq_rel-abundance.tsv").exists()
-            assert path("$projectDir/results/results/barcode02_filtered.fastq_rel-abundance.tsv").exists()
+            assert path("${params.outdir}/results/barcode01_filtered.fastq_rel-abundance.tsv").exists()
+            assert path("${params.outdir}/results/barcode02_filtered.fastq_rel-abundance.tsv").exists()
         }
     }
 }

--- a/tests/shortread.nf.test
+++ b/tests/shortread.nf.test
@@ -3,7 +3,6 @@ nextflow_pipeline {
     script "main.nf"
 
     test("Should run pipeline with test profile for shortread data") {
-        tag "seqtype-sr"
         when {
             params {
                 db = "$projectDir/assets/databases/emu_database"

--- a/tests/shortread.nf.test
+++ b/tests/shortread.nf.test
@@ -11,14 +11,14 @@ nextflow_pipeline {
                 retain_untrimmed = true
                 pipelines_testdata_base_path = "https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/refs/heads/16s/"
                 input = "https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/refs/heads/16s/samplesheet-shortread.csv"
-                outdir = "$projectDir/results"
+                outdir = outputDir
             }
         }
         then {
             assert workflow.success
             assert workflow.trace.succeeded().size() > 0 // Adjust this number based on the number of processes in your pipeline
-            assert path("$projectDir/results/results/SAMPLE_1.trimmed_1.trim.fastq-SAMPLE_1.trimmed_2.trim.fastq_rel-abundance.tsv").exists()
-            assert path("$projectDir/results/results/SAMPLE_2.trimmed_1.trim.fastq-SAMPLE_2.trimmed_2.trim.fastq_rel-abundance.tsv").exists()
+            assert path("${params.outdir}/results/SAMPLE_1.trimmed_1.trim.fastq-SAMPLE_1.trimmed_2.trim.fastq_rel-abundance.tsv").exists()
+            assert path("${params.outdir}/results/SAMPLE_2.trimmed_1.trim.fastq-SAMPLE_2.trimmed_2.trim.fastq_rel-abundance.tsv").exists()
         }
     }
 }

--- a/tests/trim-and-filter.nf.test
+++ b/tests/trim-and-filter.nf.test
@@ -1,0 +1,100 @@
+nextflow_pipeline {
+    name "Test Main Pipeline"
+    script "main.nf"
+
+    test("Should run pipeline WITH adapter trimming but WITHOUT quality filtering") {
+        when {
+            params {
+                db = "$projectDir/assets/databases/emu_database"
+                seqtype = "map-ont"
+                longread_qc_qualityfilter_minlength = 1200
+                longread_qc_qualityfilter_maxlength = 1800
+                merge_fastq_pass = "$projectDir/assets/test_assets/ci"
+                pipelines_testdata_base_path = "https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/refs/heads/16s/"
+                outdir = outputDir
+
+                // The parameters we are varying here
+                adapter_trimming = true
+                quality_filtering = false
+            }
+        }
+        then {
+            assert workflow.success
+            assert workflow.trace.succeeded().size() > 0 // Adjust this number based on the number of processes in your pipeline
+            assert path("${params.outdir}/results/barcode01.porechop_abi.fastq_rel-abundance.tsv").exists()
+            assert path("${params.outdir}/results/barcode02.porechop_abi.fastq_rel-abundance.tsv").exists()
+
+            // Ensure that Porechop ABI has ran
+            assert path("${params.outdir}/porechop_abi/barcode01.porechop_abi.log").exists()
+            assert path("${params.outdir}/porechop_abi/barcode02.porechop_abi.log").exists()
+
+            // Ensure that Filtlong has NOT run
+            assert !path("${params.outdir}/filtlong/barcode01_filtered.log").exists()
+            assert !path("${params.outdir}/filtlong/barcode02_filtered.log").exists()
+        }
+    }
+
+    test("Should run pipeline WITHOUT adapter trimming but WITH quality filtering") {
+        when {
+            params {
+                db = "$projectDir/assets/databases/emu_database"
+                seqtype = "map-ont"
+                longread_qc_qualityfilter_minlength = 1200
+                longread_qc_qualityfilter_maxlength = 1800
+                merge_fastq_pass = "$projectDir/assets/test_assets/ci"
+                pipelines_testdata_base_path = "https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/refs/heads/16s/"
+                outdir = outputDir
+
+                // The parameters we are varying here
+                adapter_trimming = false
+                quality_filtering = true
+            }
+        }
+        then {
+            assert workflow.success
+            assert workflow.trace.succeeded().size() > 0 // Adjust this number based on the number of processes in your pipeline
+            assert path("${params.outdir}/results/barcode01_filtered.fastq_rel-abundance.tsv").exists()
+            assert path("${params.outdir}/results/barcode02_filtered.fastq_rel-abundance.tsv").exists()
+
+            // Ensure that Porechop ABI has NOT ran
+            assert !path("${params.outdir}/porechop_abi/barcode01.porechop_abi.log").exists()
+            assert !path("${params.outdir}/porechop_abi/barcode02.porechop_abi.log").exists()
+
+            // Ensure that Filtlong HAS run
+            assert path("${params.outdir}/filtlong/barcode01_filtered.log").exists()
+            assert path("${params.outdir}/filtlong/barcode02_filtered.log").exists()
+        }
+    }
+
+    test("Should run pipeline WITH adapter trimming and WITH quality filtering") {
+        when {
+            params {
+                db = "$projectDir/assets/databases/emu_database"
+                seqtype = "map-ont"
+                longread_qc_qualityfilter_minlength = 1200
+                longread_qc_qualityfilter_maxlength = 1800
+                merge_fastq_pass = "$projectDir/assets/test_assets/ci"
+                pipelines_testdata_base_path = "https://raw.githubusercontent.com/genomic-medicine-sweden/test-datasets/refs/heads/16s/"
+                outdir = outputDir
+
+                // The parameters we are varying here
+                adapter_trimming = true
+                quality_filtering = true
+            }
+        }
+        then {
+            assert workflow.success
+            assert workflow.trace.succeeded().size() > 0 // Adjust this number based on the number of processes in your pipeline
+            assert path("${params.outdir}/results/barcode01_filtered.fastq_rel-abundance.tsv").exists()
+            assert path("${params.outdir}/results/barcode02_filtered.fastq_rel-abundance.tsv").exists()
+
+            // Ensure that Porechop ABI has ran
+            assert path("${params.outdir}/porechop_abi/barcode01.porechop_abi.log").exists()
+            assert path("${params.outdir}/porechop_abi/barcode02.porechop_abi.log").exists()
+
+            // Ensure that Filtlong HAS run
+            assert path("${params.outdir}/filtlong/barcode01_filtered.log").exists()
+            assert path("${params.outdir}/filtlong/barcode02_filtered.log").exists()
+        }
+    }
+}

--- a/workflows/taco.nf
+++ b/workflows/taco.nf
@@ -56,10 +56,14 @@ workflow TACO {
         //
         NANOPLOT_UNPROCESSED_READS(ch_reads)
         ch_versions = ch_versions.mix(NANOPLOT_UNPROCESSED_READS.out.versions.first())
-        ch_multiqc_files = ch_multiqc_files.mix(NANOPLOT_UNPROCESSED_READS.out.txt.collect{ it[1] })
+        ch_multiqc_files = ch_multiqc_files.mix(
+            NANOPLOT_UNPROCESSED_READS.out.txt.collect{ it[1] }
+        )
 
-        if (params.adapter_trimming && !params.quality_filtering) {
-
+        //
+        // Optional adapter trimming
+        //
+        if (params.adapter_trimming) {
             //
             // MODULE: Run Porechop to trim ONT adapters
             //
@@ -67,49 +71,33 @@ workflow TACO {
 
             PORECHOP_ABI.out.reads.map {
                 meta, reads -> [meta + [single_end: 1], reads]
-            }.set { ch_processed_reads }
+            }.set{ ch_optionally_trimmed_reads }
 
             ch_versions = ch_versions.mix(PORECHOP_ABI.out.versions.first())
-            ch_multiqc_files = ch_multiqc_files.mix(PORECHOP_ABI.out.log.collect{ it[1] })
+            ch_multiqc_files = ch_multiqc_files.mix(
+                PORECHOP_ABI.out.log.collect{ it[1] }
+            )
+        } else {
+            ch_reads.set{ ch_optionally_trimmed_reads }
+        }
 
-        } else if (!params.adapter_trimming && params.quality_filtering) {
-
+        //
+        // Optional quality filtering
+        //
+        if (params.quality_filtering) {
             //
             // MODULE: Run filtlong to filter on read length
             //
-            FILTLONG(ch_reads.map {
-                meta, reads -> [meta, [], reads]
-            }).reads.set { ch_processed_reads}
-
-            ch_versions = ch_versions.mix(FILTLONG.out.versions.first())
-            ch_multiqc_files = ch_multiqc_files.mix(FILTLONG.out.log.collect{ it[1] })
-
-        } else if (params.adapter_trimming && params.quality_filtering) {
-
-            //
-            // MODULE: Run Porechop to trim ONT adapters
-            //
-            PORECHOP_ABI(ch_reads, [])
-
-            PORECHOP_ABI.out.reads.map {
-                meta, reads -> [meta + [single_end: 1], reads]
-            }.set { ch_clipped_reads }
-
-            ch_versions = ch_versions.mix(PORECHOP_ABI.out.versions.first())
-            ch_multiqc_files = ch_multiqc_files.mix(PORECHOP_ABI.out.log.collect{ it[1] })
-
-            //
-            // MODULE: Run filtlong to filter on read length
-            //
-            FILTLONG(ch_clipped_reads.map {
+            FILTLONG(ch_optionally_trimmed_reads.map {
                 meta, reads -> [meta, [], reads]
             }).reads.set { ch_processed_reads }
 
             ch_versions = ch_versions.mix(FILTLONG.out.versions.first())
-            ch_multiqc_files = ch_multiqc_files.mix(FILTLONG.out.log.collect{ it[1] })
-
+            ch_multiqc_files = ch_multiqc_files.mix(
+                FILTLONG.out.log.collect{ it[1] }
+            )
         } else {
-            ch_reads.set { ch_processed_reads }
+            ch_optionally_trimmed_reads.set{ ch_processed_reads }
         }
 
         //
@@ -117,7 +105,9 @@ workflow TACO {
         //
         NANOPLOT_PROCESSED_READS(ch_processed_reads)
         ch_versions = ch_versions.mix(NANOPLOT_PROCESSED_READS.out.versions.first())
-        ch_multiqc_files = ch_multiqc_files.mix(NANOPLOT_PROCESSED_READS.out.txt.collect{ it[1] })
+        ch_multiqc_files = ch_multiqc_files.mix(
+            NANOPLOT_PROCESSED_READS.out.txt.collect{ it[1] }
+        )
 
     } else if (params.seqtype == "sr") {
 
@@ -128,7 +118,9 @@ workflow TACO {
             CUTADAPT(ch_reads)
             CUTADAPT.out.reads.set { ch_processed_reads }
             ch_versions = ch_versions.mix(CUTADAPT.out.versions.first())
-            ch_multiqc_files = ch_multiqc_files.mix(CUTADAPT.out.log.collect{ it[1] })
+            ch_multiqc_files = ch_multiqc_files.mix(
+                CUTADAPT.out.log.collect{ it[1] }
+            )
         } else {
             ch_reads.set { ch_processed_reads }
         }
@@ -140,23 +132,34 @@ workflow TACO {
         //
         // MODULE: Downsample reads
         //
-        SEQTK_SAMPLE( ch_processed_reads, params.sample_size ).reads.set { ch_processed_sampled_reads }
+        // Fold in the sample size in the tuple
+        ch_processed_reads.map { reads ->
+            reads + params.sample_size
+        }.set{ ch_processed_reads_with_sample_size }
+
+        SEQTK_SAMPLE(
+            ch_processed_reads_with_sample_size
+        ).reads.set{ ch_processed_optionally_sampled_reads }
+
         ch_versions = ch_versions.mix(SEQTK_SAMPLE.out.versions)
     } else {
-        ch_processed_reads.set { ch_processed_sampled_reads }
+        ch_processed_reads.set{ ch_processed_optionally_sampled_reads }
     }
 
     //
     // MODULE: run EMU abundance calculation
     //
-    EMU_ABUNDANCE(ch_processed_sampled_reads)
+    EMU_ABUNDANCE(ch_processed_optionally_sampled_reads)
     ch_versions = ch_versions.mix(EMU_ABUNDANCE.out.versions.first())
 
     if (params.run_krona) {
         //
         // MODULE: Run krona plot
         //
-        KRONA_KTIMPORTTAXONOMY(EMU_ABUNDANCE.out.report, file(params.krona_taxonomy_tab, checkExists: true))
+        KRONA_KTIMPORTTAXONOMY(
+            EMU_ABUNDANCE.out.report,
+            file(params.krona_taxonomy_tab, checkExists: true)
+        )
         ch_versions = ch_versions.mix(KRONA_KTIMPORTTAXONOMY.out.versions.first())
     }
 
@@ -173,25 +176,29 @@ workflow TACO {
     //
     // MODULE: Generate PHYLOSEQ object
     if (params.phyloseq) {
-        ch_tax_file = Channel.fromPath("$projectDir/assets/databases/emu_database/taxonomy.tsv", checkIfExists: true)
         report_ch = EMU_ABUNDANCE.out.report
-
         all_reports_ch = report_ch
             .map { meta, path -> path }
             .collect()
-
         COMBINE_REPORTS (
             all_reports_ch
         )
 
+        ch_tax_file = Channel.fromPath(
+            "$projectDir/assets/databases/emu_database/taxonomy.tsv",
+            checkIfExists: true
+        )
         PHYLOSEQ_OBJECT (
             COMBINE_REPORTS.out.combinedreport,
             ch_tax_file
         )
+
         ch_versions = ch_versions.mix(PHYLOSEQ_OBJECT.out.versions)
     }
 
-    CUSTOM_DUMPSOFTWAREVERSIONS(ch_versions.unique().collectFile(name: 'collated_versions.yml'))
+    CUSTOM_DUMPSOFTWAREVERSIONS(
+        ch_versions.unique().collectFile(name: 'collated_versions.yml')
+    )
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/workflows/taco.nf
+++ b/workflows/taco.nf
@@ -63,7 +63,7 @@ workflow TACO {
             //
             // MODULE: Run Porechop to trim ONT adapters
             //
-            PORECHOP_ABI(ch_reads)
+            PORECHOP_ABI(ch_reads, [])
 
             PORECHOP_ABI.out.reads.map {
                 meta, reads -> [meta + [single_end: 1], reads]
@@ -89,7 +89,7 @@ workflow TACO {
             //
             // MODULE: Run Porechop to trim ONT adapters
             //
-            PORECHOP_ABI(ch_reads)
+            PORECHOP_ABI(ch_reads, [])
 
             PORECHOP_ABI.out.reads.map {
                 meta, reads -> [meta + [single_end: 1], reads]


### PR DESCRIPTION
This PR implements #92:

- Adding tests for the main options of the workflow
- Simplifies the logic to avoid repetitions
- Adds `nextflow lint` to the CI process
- Various other cleanups and fixes