### PR TITLE
Hotfix: Fix broken container image name for Nanoplot 1.46.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+- Fixed broken container image URL for NanoPlot
+
+### Changed
+
 ## [v0.6.0]
 
 ### Added

--- a/modules/nf-core/nanoplot/main.nf
+++ b/modules/nf-core/nanoplot/main.nf
@@ -5,7 +5,7 @@ process NANOPLOT {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/nanoplot:1.46.1--pyhdfd78af_0' :
-        'biocontainers/nanoplot:1.46.1--pyhdfd78af_0' }"
+        'quay.io/biocontainers/nanoplot:1.46.1--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(ontfile)


### PR DESCRIPTION
This fixes a broken image name for Docker containers, adding a missing `quay.io` part.

I'm targeting this at main currently, as main and dev have diverged their histories, and so we can't go via dev currently.

If we fix the histories I can target dev first instead.